### PR TITLE
fix: watch-run callback function params error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ export default class WXAppPlugin {
 		compiler.plugin(
 			'watch-run',
 			this.try(async compiler => {
-				await this.run(compiler.compiler);
+				await this.run(compiler);
 			})
 		);
 


### PR DESCRIPTION
should not be `compiler. compiler `, maybe a typo for `compiler `